### PR TITLE
Allow the console to open at a directory

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,7 +1,16 @@
 import useFetch from 'use-http';
+import { useLocation } from "react-router-dom";
 
 export function useInitializeSession() {
-  return useFetch("/ssh/host/127.0.0.1");
+  var path
+  const dir = new URLSearchParams(useLocation().search).get('dir')
+  if (dir) {
+    path = `/ssh/host/127.0.0.1?dir=${dir}`;
+  } else {
+    path = "/ssh/host/127.0.0.1";
+  }
+
+  return useFetch(path);
 }
 
 export function useInstallSshKey() {


### PR DESCRIPTION
The `dir` query parameter is passed onto the API, which triggers the console to open at the specified working directory:

* `GET /console/terminal?dir=/path/to/dir`