### PR TITLE
Allow limited connections on certain errors

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,9 +1,7 @@
 import useFetch from 'use-http';
-import { useLocation } from "react-router-dom";
 
-export function useInitializeSession() {
-  var path
-  const dir = new URLSearchParams(useLocation().search).get('dir')
+export function useInitializeSession(dir) {
+  let path
   if (dir) {
     path = `/ssh/host/127.0.0.1?dir=${dir}`;
   } else {

--- a/src/useRequestedDirectory.js
+++ b/src/useRequestedDirectory.js
@@ -1,0 +1,30 @@
+import { useRef } from 'react';
+import { useHistory } from "react-router-dom"
+
+function useRequestedDirectory() {
+  const history = useHistory();
+  const dirRef = useRef(new URLSearchParams(history.location.search).get('dir'));
+
+  return {
+    requestedDir: dirRef.current,
+    clearSearchParams: () => {
+      if (dirRef.current != null) {
+        // Deliberately use `window.history` and `window.location` instead of
+        // `history` and location provided by react-router in order to avoid a
+        // re-rendering.
+        //
+        // Due to (possible) idiosyncrasies in
+        // react-router/react-transition-group, using `history` would result
+        // in a new page being animated in with the now incorrect search
+        // params, which would result in the wrong directory being displayed.
+        //
+        // There may be a better way of avoiding this.
+        const url = new URL(window.location);
+        url.searchParams.delete('dir');
+        window.history.pushState({}, '', url);
+      }
+    },
+  };
+}
+
+export default useRequestedDirectory;

--- a/src/useTerminal.js
+++ b/src/useTerminal.js
@@ -258,33 +258,61 @@ function addBasicErrorToast(responseBody, addToast) {
       The change directory feature has been disabled.
     </p>
   )
-  let body = (
-    <div>
-      <p>
-        Unfortunately there has been a problem connecting to your terminal
-        console session.  Please try again and, if problems persist, help us
-        to more quickly rectify the problem by contacting us and letting us
-        know.
-      </p>
-      {limitedFeatures}
-    </div>
+  let message = (
+    <p>
+      Unfortunately there has been a problem connecting to your terminal
+      console session.  Please try again and, if problems persist, help us
+      to more quickly rectify the problem by contacting us and letting us
+      know.
+    </p>
   );
 
   // Update the error for SFTP errors
   if (code === 'Unexpected SFTP STDOUT') {
     debug("user's terminal emitted data to STDOUT in a non-interactive shell");
-    body = (
-      <div>
-        <p>
-          Unfortunately there has been a problem when polling your shell for
-          its current directory. This is typically because a profile script
-          (e.g. <code>.bashrc</code>) has printed to Standard Output within
-          a <i>non-interactive login shell</i>.
-        </p>
-        {limitedFeatures}
-      </div>
+    message = (
+      <p>
+        Unfortunately there has been a problem when polling your shell for
+        its current directory. This is typically because a profile script
+        (e.g. <code>.bashrc</code>) has printed to Standard Output within
+        a <i>non-interactive login shell</i>.
+      </p>
     );
+  } else if (code === "Missing Directory") {
+    message = (
+      <p>
+        Cannot open the requested directory as it does not exist!
+      </p>
+    )
+  } else if (code === "Not A Directory") {
+    message = (
+      <p>
+        Cannot open the requested directory as it is not a directory!
+      </p>
+    )
+  } else if (code === "Permission Denied") {
+    message = (
+      <p>
+        You have insufficient permissions to open the requested directory!
+      </p>
+    );
+  } else if (code === "Invalid Characters") {
+    message = (
+      <p>
+        Cannot open the requested directory as it contains invalid
+        characters. Please contact us if your believe this to be an
+        error.
+      </p>
+    )
   }
+
+  // Generate the message
+  const body = (
+    <p>
+      {message}
+      {limitedFeatures}
+    </p>
+  );
 
   // Display the toast
   addToast({

--- a/src/useTerminal.js
+++ b/src/useTerminal.js
@@ -100,16 +100,14 @@ function useTerminal(containerRef) {
     const term = termRef.current;
     debug('initializing session');
     initializeSession().then((responseBody) => {
-      // Prompts the user if a basic error has occurred
-      // and continues with the connection
-      const basicError = response.status === 422 && response.data.errors.every((e) => {
-        return e.basic;
+      const recoverable = response.status === 422 && response.data.errors.every((e) => {
+        return e.recoverable;
       })
-      if (basicError) {
-        addBasicErrorToast(responseBody, requestedDir, addToast);
+      if (recoverable) {
+        addRecoverableToast(responseBody, requestedDir, addToast);
       }
 
-      if (response.ok || basicError) {
+      if (response.ok || recoverable) {
         const [ url, params ] = buildSocketIOParams(config);
         debug('initializing socket: %s %o', url, params);
         const socket = io.connect(url, params);
@@ -251,7 +249,7 @@ function useTerminal(containerRef) {
   return { focus, onDisconnect, onReconnect, resizeTerminal, terminalState, title };
 }
 
-function addBasicErrorToast(responseBody, requestedDir, addToast) {
+function addRecoverableToast(responseBody, requestedDir, addToast) {
   const code = utils.errorCode(responseBody);
 
   let body;


### PR DESCRIPTION
The webapp will now make the SSH connection on certain error conditions. This is to allow the user to rectify the issue.

The key errors are:

* They are emitting data to STDOUT within their bashrc, or
* Various missing directories/ permission errors.