### PR TITLE
Show shutdown warning for each shutdown

### DIFF
--- a/src/useTerminal.js
+++ b/src/useTerminal.js
@@ -115,6 +115,7 @@ function useTerminal(containerRef) {
         debug('initializing socket: %s %o', url, params);
         const socket = io.connect(url, params);
         socketRef.current = socket;
+        shutdownMessageShown.current = false;
         updateTerminalState(term, 'connected');
 
         term.onData(function (data) {


### PR DESCRIPTION
If the users session is shutdown, and they reconnect once the server is restarted, they now get a second shutdown warning if that second session is also shutdown.

Should have been part of #45 